### PR TITLE
Add CLI args option to constructor and blameByFile method

### DIFF
--- a/src/Blamer.js
+++ b/src/Blamer.js
@@ -2,15 +2,17 @@ var blamerVCS = {
     'git': require("./vcs/git"),
     'svn': require("./vcs/svn")
 };
-var Blamer = function Blamer(type) {
+var Blamer = function Blamer(type, args) {
+    this.args = args;
     this.type = type || 'git';
 };
 
-Blamer.prototype.blameByFile = function blameByFile(file) {
+Blamer.prototype.blameByFile = function blameByFile(file, args) {
     if (!blamerVCS.hasOwnProperty(this.type)) {
         throw new Error('VCS "' + this.type + '" don\'t supported');
     }
-    return blamerVCS[this.type](file);
+    args = typeof args === 'string' ? args : this.args;
+    return blamerVCS[this.type](file, args);
 };
 
 Blamer.prototype.getType = function () {

--- a/src/vcs/git.js
+++ b/src/vcs/git.js
@@ -16,11 +16,12 @@ function convertStringToObject(line) {
   return commit;
 }
 
-module.exports = function(file) {
+module.exports = function(file, args) {
+  args = typeof args === 'string' ? args : '-w';
   var realFile = path.basename(file);
   var cwd = path.dirname(file);
   return new Promise(function(resolve, reject) {
-    exec('git blame -w ' + realFile, {
+    exec('git blame ' + args + ' ' + realFile, {
       cwd: cwd,
       maxBuffer: 1024 * 1024
     }, function(error, stdout, stderr) {

--- a/src/vcs/svn.js
+++ b/src/vcs/svn.js
@@ -4,7 +4,8 @@ var Promise = require('bluebird');
 var xml2js = require("xml2js");
 
 
-module.exports = function(file) {
+module.exports = function(file, args) {
+  args = typeof args === 'string' ? args : '--xml';
   var realFile = path.basename(file);
   var cwd = path.dirname(file);
 
@@ -34,7 +35,7 @@ module.exports = function(file) {
   }
 
   return new Promise(function(resolve, reject) {
-    exec('svn blame ' + realFile + ' --xml', {
+    exec('svn blame ' + realFile + ' ' + args, {
       cwd: cwd,
       maxBuffer: 1024 * 1024
     }, function(error, stdout, stderr) {

--- a/test/BlamerSpec.js
+++ b/test/BlamerSpec.js
@@ -3,7 +3,10 @@ describe("Blamer", function(){
 
     beforeEach(function () {
         file = 'zzz';
-        git = env.stub().withArgs(file).returns('resultPromise');
+        git = env.stub();
+        git.withArgs(file, '--o').returns('promise (constructor args)');
+        git.withArgs(file, '--a').returns('promise (call args)');
+        git.withArgs(file).returns('promise (default args)');
         Blamer = proxyquire(sourcePath + 'Blamer',{
             "./vcs/git": git
         });
@@ -20,8 +23,17 @@ describe("Blamer", function(){
         sut.getType().should.equal('git');
     });
 
-    it('should get data from git vcs', function (){
-        sut.blameByFile(file).should.equal('resultPromise');
+    it('should get data from git with default args', function (){
+        sut.blameByFile(file).should.equal('promise (default args)');
+    });
+
+    it('should get data from git with args passed to constructor', function (){
+        var blamer = new Blamer('git', '--o');
+        blamer.blameByFile(file).should.equal('promise (constructor args)');
+    });
+
+    it('should get data from git with args passed to method call', function (){
+        sut.blameByFile(file, '--a').should.equal('promise (call args)');
     });
 
     it('should throw exception in type of vcs dont supported', function (){

--- a/test/vcs/gitSpec.js
+++ b/test/vcs/gitSpec.js
@@ -44,6 +44,28 @@ describe('Git', function() {
     );
   });
 
+  it('should exec git blame with args', function() {
+    sut(fileRaw, '-M -w');
+    exec.should.have.been.calledWith(
+      'git blame -M -w ' + file, {
+        cwd: cwd,
+        maxBuffer: 1024 * 1024
+      },
+      sinon.match.any
+    );
+  });
+
+  it('should exec git blame without args', function() {
+    sut(fileRaw, '');
+    exec.should.have.been.calledWith(
+      'git blame  ' + file, {
+        cwd: cwd,
+        maxBuffer: 1024 * 1024
+      },
+      sinon.match.any
+    );
+  });
+
   it('should parse result of blame', function(done) {
     sut(fileRaw).then(callback).finally(function() {
       var res = {};

--- a/test/vcs/svnSpec.js
+++ b/test/vcs/svnSpec.js
@@ -45,6 +45,28 @@ describe('SVN', function() {
     );
   });
 
+  it('should exec svn blame with args', function() {
+    sut(fileRaw, '--xml --verbose');
+    exec.should.have.been.calledWith(
+      'svn blame ' + file + ' --xml --verbose', {
+        cwd: cwd,
+        maxBuffer: 1024 * 1024
+      },
+      sinon.match.any
+    );
+  });
+
+  it('should exec svn blame without args', function() {
+    sut(fileRaw, '');
+    exec.should.have.been.calledWith(
+      'svn blame ' + file + ' ', {
+        cwd: cwd,
+        maxBuffer: 1024 * 1024
+      },
+      sinon.match.any
+    );
+  });
+
   it('should parse result of blame', function(done) {
     sut(fileRaw).then(callback).finally(function() {
       var res = {};


### PR DESCRIPTION
```
let blamer = new Blamer('git', '-w -M');
blamer.blameByFile(file)            // git blame -w -M
blamer.blameByFile(file, '-M -C')   // git blame -M -C
blamer.blameByFile(file, '')        // git blame
blamer = new Blamer('git');
blamer.blameByFile(file)            // git blame -w
```

This PR closes Issue #2.