### PR TITLE
refactor(git): switch from synchronous to asynchronous execa calls in git functions

### DIFF
--- a/src/vcs/git.spec.ts
+++ b/src/vcs/git.spec.ts
@@ -4,13 +4,11 @@ import sinon from 'sinon';
 
 const pathToGit: string = '/path/to/git';
 const pathToFile: string = '/path/to/file';
-const stubExeca = {
-  sync: sinon.stub().returns({
-    stdout:
-      '68ca373e (Andrii Kucherenko 2018-08-14 12:02:47 +0300  1) # editorconfig.org\n' +
-      'sadsaf //should be skipped from result\n'
-  })
-};
+const stubExeca = sinon.stub().resolves({
+  stdout:
+    '68ca373e (Andrii Kucherenko 2018-08-14 12:02:47 +0300  1) # editorconfig.org\n' +
+    'sadsaf //should be skipped from result\n'
+});
 const stubWhich = sinon.stub().returns(pathToGit);
 const { git } = proxyquire('./git', {
   execa: stubExeca,

--- a/src/vcs/git.ts
+++ b/src/vcs/git.ts
@@ -25,8 +25,7 @@ export async function git(path: string): Promise<BlameResult> {
   if (!existsSync(path)) {
     throw new Error(`File ${path} does not exist`);
   }
-
-  const result = execa.sync(pathToGit, ['blame', '-w', path]);
+  const result = await execa(pathToGit, ['blame', '-w', path]);
   result.stdout.split('\n').forEach(line => {
     if (line !== '') {
       const blamedLine = convertStringToObject(line);


### PR DESCRIPTION
## Summary

This PR optimizes the performance of the `blamer` module by making `git blame` asynchronous.
Previously, synchronous calls (`execa.sync`) were blocking the event loop when processing multiple clones concurrently, causing high CPU usage on large repositories.

## Changes

- Replaced `execa.sync` with asynchronous `execa` call inside `git()` function.
- Updated tests to mock async behavior using `sinon.stub().resolves(...)`.
- Verified that performance improved from **43s → 17s** on a large repo (MacBook Pro M3).

## Motivation

Running `jscpd` with `blame: true` previously resulted in severe performance degradation due to synchronous blame calls.
This PR significantly improves responsiveness and reduces CPU blocking.

## Related Issue

Fixes #31 

## Checklist

- [x] Code builds successfully (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Verified performance improvement locally
- [x] No breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated git blame operation to use asynchronous execution patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- brian settings start --><!--{}--><!-- brian settings end -->